### PR TITLE
Add Cairo1 program bootloader implementation

### DIFF
--- a/docs/cairo1_program_bootloader.md
+++ b/docs/cairo1_program_bootloader.md
@@ -1,0 +1,110 @@
+# Cairo1 Program Bootloader
+
+This document summarizes the minimal Cairo 0 bootloader that executes a single
+Cairo 1 program while reusing the existing simple bootloader infrastructure.
+The implementation lives in
+`starkware/cairo/bootloaders/cairo1_program_bootloader/cairo1_program_bootloader.cairo`
+and delegates nearly all heavy lifting to `run_simple_bootloader` so builtin
+handling stays identical to the battle-tested task pipeline.
+
+## Overview
+
+* Accept a compiled Cairo 1 executable (plain program, no contract wrapper) and
+  its serialized program input.
+* Convert that payload into a `SimpleBootloaderInput` with a single
+  `RunProgramTask` using a small Python helper.
+* Invoke `run_simple_bootloader`, which loads the program, wires builtin
+  pointers, executes the code, and validates that builtin usage matches the
+  Cairo runner expectations.
+
+## Cairo entry point
+
+The Cairo program mirrors `simple_bootloader.cairo`: it prepares the optional
+builtins, runs the simple bootloader, and replays the builtin verification
+helpers.【F:src/starkware/cairo/bootloaders/cairo1_program_bootloader/cairo1_program_bootloader.cairo†L1-L67】
+
+```cairo
+%builtins output pedersen range_check ecdsa bitwise ec_op keccak poseidon range_check96 add_mod mul_mod
+
+from starkware.cairo.bootloaders.simple_bootloader.run_simple_bootloader import (
+    run_simple_bootloader,
+)
+from starkware.cairo.bootloaders.simple_bootloader.verify_builtins import (
+    handle_ec_op_builtin_verification,
+    handle_ecdsa_builtin_verification,
+    handle_keccak_builtin_verification,
+    handle_uninitialized_ec_op_builtin,
+    handle_uninitialized_ecdsa_builtin,
+    handle_uninitialized_keccak_builtin,
+)
+from starkware.cairo.common.cairo_builtins import HashBuiltin, PoseidonBuiltin
+
+func main{
+    output_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr,
+    ecdsa_ptr,
+    bitwise_ptr,
+    ec_op_ptr,
+    keccak_ptr,
+    poseidon_ptr: PoseidonBuiltin*,
+    range_check96_ptr,
+    add_mod_ptr,
+    mul_mod_ptr,
+}() {
+    alloc_locals;
+    %{
+        from starkware.cairo.bootloaders.cairo1_program_bootloader.single_program_input import (
+            build_single_program_bootloader_input,
+        )
+
+        simple_bootloader_input = build_single_program_bootloader_input(program_input)
+    %}
+
+    let (local ec_op_ptr) = handle_uninitialized_ec_op_builtin(ec_op_ptr=ec_op_ptr);
+    let (local keccak_ptr) = handle_uninitialized_keccak_builtin(keccak_ptr=keccak_ptr);
+    let (local ecdsa_ptr) = handle_uninitialized_ecdsa_builtin(ecdsa_ptr=ecdsa_ptr);
+
+    run_simple_bootloader();
+
+    let (local ec_op_ptr) = handle_ec_op_builtin_verification(
+        ec_op_ptr=ec_op_ptr, ec_op_ptr_orig=ec_op_ptr_orig, ec_op_start_ptr=ec_op_start_ptr
+    );
+    let (local keccak_ptr) = handle_keccak_builtin_verification(
+        keccak_ptr=keccak_ptr, keccak_ptr_orig=keccak_ptr_orig, keccak_start_ptr=keccak_start_ptr
+    );
+    let (local ecdsa_ptr) = handle_ecdsa_builtin_verification(
+        ecdsa_ptr=ecdsa_ptr, ecdsa_ptr_orig=ecdsa_ptr_orig, ecdsa_start_ptr=ecdsa_start_ptr
+    );
+
+    return ();
+}
+```
+
+The output format and builtin pointer updates remain exactly the same as the
+simple bootloader because the inner logic is unchanged.【F:src/starkware/cairo/bootloaders/simple_bootloader/run_simple_bootloader.cairo†L52-L203】
+
+## Input conversion helper
+
+The Python helper that feeds the hint lives in
+`starkware/cairo/bootloaders/cairo1_program_bootloader/single_program_input.py`.
+It converts a plain dictionary into the structured `SimpleBootloaderInput`
+consumed by the existing hints.  The helper accepts a Cairo program expressed as
+JSON (or an already-loaded `Program` object), optional calldata, and an optional
+hash function selector.  When the official `simple_bootloader.objects`
+definitions are available they are reused; otherwise lightweight fallback
+implementations keep the bootloader usable in stripped environments.【F:src/starkware/cairo/bootloaders/cairo1_program_bootloader/single_program_input.py†L1-L104】
+
+## Expected inputs and outputs
+
+* **Inputs:** dictionary with at least a `"program"` entry holding the compiled
+  Cairo 1 program, plus optional `"program_input"`, `"program_hash_function"`,
+  `"single_page"`, and `"fact_topologies_path"` fields.
+* **Outputs:** identical to the simple bootloader—number of tasks (always 1),
+  program hash, then the Cairo program output segment.
+* **Builtins:** initialized and verified via the same helpers used by the simple
+  bootloader, ensuring compatibility with existing tooling.【F:src/starkware/cairo/bootloaders/simple_bootloader/verify_builtins.cairo†L1-L126】
+
+With this wiring, a host can load Cairo 1 bytecode and calldata into the Cairo 0
+VM without dealing with the broader task abstraction or modifying the proven
+simple bootloader pipeline.

--- a/src/starkware/cairo/bootloaders/cairo1_program_bootloader/BUILD
+++ b/src/starkware/cairo/bootloaders/cairo1_program_bootloader/BUILD
@@ -1,0 +1,14 @@
+load("//src/starkware/cairo/lang:cairo_rules.bzl", "cairo_binary")
+
+cairo_binary(
+    name = "cairo1_program_bootloader",
+    cairoopts = [
+        "--debug_info_with_source",
+        "--proof_mode",
+    ],
+    compiled_program_name = "cairo1_program_bootloader_compiled.json",
+    main = "cairo1_program_bootloader.cairo",
+    deps = ["//src/starkware/cairo/bootloaders/simple_bootloader:simple_bootloader_lib"],
+)
+
+package(default_visibility = ["//visibility:public"])

--- a/src/starkware/cairo/bootloaders/cairo1_program_bootloader/cairo1_program_bootloader.cairo
+++ b/src/starkware/cairo/bootloaders/cairo1_program_bootloader/cairo1_program_bootloader.cairo
@@ -1,0 +1,79 @@
+%builtins output pedersen range_check ecdsa bitwise ec_op keccak poseidon range_check96 add_mod mul_mod
+
+from starkware.cairo.bootloaders.simple_bootloader.run_simple_bootloader import (
+    run_simple_bootloader,
+)
+from starkware.cairo.bootloaders.simple_bootloader.verify_builtins import (
+    handle_ec_op_builtin_verification,
+    handle_ecdsa_builtin_verification,
+    handle_keccak_builtin_verification,
+    handle_uninitialized_ec_op_builtin,
+    handle_uninitialized_ecdsa_builtin,
+    handle_uninitialized_keccak_builtin,
+)
+from starkware.cairo.common.cairo_builtins import HashBuiltin, PoseidonBuiltin
+
+// Bootloads a single Cairo 1 program by delegating to the simple bootloader with a
+// synthetic single-task input. The Python hint populates `simple_bootloader_input`
+// from the provided program payload.
+//
+// Hint arguments:
+// * program_input - dictionary produced by the host that encodes the compiled
+//   Cairo 1 program and its calldata.
+func main{
+    output_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr,
+    ecdsa_ptr,
+    bitwise_ptr,
+    ec_op_ptr,
+    keccak_ptr,
+    poseidon_ptr: PoseidonBuiltin*,
+    range_check96_ptr,
+    add_mod_ptr,
+    mul_mod_ptr,
+}() {
+    alloc_locals;
+    %{
+        from starkware.cairo.bootloaders.cairo1_program_bootloader.single_program_input import (
+            build_single_program_bootloader_input,
+        )
+
+        simple_bootloader_input = build_single_program_bootloader_input(program_input)
+    %}
+
+    // Handle ec_op builtin. See docstring of `handle_uninitialized_ec_op_builtin` for more info.
+    local ec_op_ptr_orig = ec_op_ptr;
+    let (local ec_op_ptr) = handle_uninitialized_ec_op_builtin(ec_op_ptr=ec_op_ptr);
+    local ec_op_start_ptr = ec_op_ptr;
+
+    // Handle keccak builtin. See docstring of `handle_uninitialized_keccak_builtin` for more info.
+    local keccak_ptr_orig = keccak_ptr;
+    let (local keccak_ptr) = handle_uninitialized_keccak_builtin(keccak_ptr=keccak_ptr);
+    local keccak_start_ptr = keccak_ptr;
+
+    // Handle ecdsa builtin. See docstring of `handle_uninitialized_ecdsa_builtin` for more info.
+    local ecdsa_ptr_orig = ecdsa_ptr;
+    let (local ecdsa_ptr) = handle_uninitialized_ecdsa_builtin(ecdsa_ptr=ecdsa_ptr);
+    local ecdsa_start_ptr = ecdsa_ptr;
+
+    // Execute the wrapped simple bootloader.
+    run_simple_bootloader();
+
+    // Verify the ec_op builtin.
+    let (local ec_op_ptr) = handle_ec_op_builtin_verification(
+        ec_op_ptr=ec_op_ptr, ec_op_ptr_orig=ec_op_ptr_orig, ec_op_start_ptr=ec_op_start_ptr
+    );
+
+    // Verify the keccak builtin.
+    let (local keccak_ptr) = handle_keccak_builtin_verification(
+        keccak_ptr=keccak_ptr, keccak_ptr_orig=keccak_ptr_orig, keccak_start_ptr=keccak_start_ptr
+    );
+
+    // Verify the ecdsa builtin.
+    let (local ecdsa_ptr) = handle_ecdsa_builtin_verification(
+        ecdsa_ptr=ecdsa_ptr, ecdsa_ptr_orig=ecdsa_ptr_orig, ecdsa_start_ptr=ecdsa_start_ptr
+    );
+
+    return ();
+}

--- a/src/starkware/cairo/bootloaders/cairo1_program_bootloader/single_program_input.py
+++ b/src/starkware/cairo/bootloaders/cairo1_program_bootloader/single_program_input.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from starkware.cairo.bootloaders.hash_program import HashFunction
+from starkware.cairo.lang.compiler.program import Program
+
+try:
+    from starkware.cairo.bootloaders.simple_bootloader.objects import (
+        RunProgramTask as _RunProgramTask,
+        SimpleBootloaderInput as _SimpleBootloaderInput,
+    )
+except ImportError:  # pragma: no cover - fallback for stripped environments.
+    _RunProgramTask = None
+    _SimpleBootloaderInput = None
+
+
+@dataclass
+class _FallbackRunProgramTask:
+    program: Program
+    program_input: Any
+    program_hash_function: int
+
+    def get_program(self) -> Program:
+        return self.program
+
+
+@dataclass
+class _FallbackSimpleBootloaderInput:
+    tasks: List[_FallbackRunProgramTask]
+    fact_topologies_path: Optional[str]
+    single_page: bool
+
+    @classmethod
+    def Schema(cls):  # pragma: no cover - compatibility shim.
+        class _Schema:
+            def load(self, data: Dict[str, Any]) -> "_FallbackSimpleBootloaderInput":
+                return _FallbackSimpleBootloaderInput(**data)
+
+        return _Schema()
+
+
+def _resolve_task_class():
+    return _RunProgramTask if _RunProgramTask is not None else _FallbackRunProgramTask
+
+
+def _resolve_input_class():
+    return (
+        _SimpleBootloaderInput
+        if _SimpleBootloaderInput is not None
+        else _FallbackSimpleBootloaderInput
+    )
+
+
+def _parse_program(raw_program: Any) -> Program:
+    if isinstance(raw_program, Program):
+        return raw_program
+    if not isinstance(raw_program, Dict):
+        raise TypeError("program must be a Program object or a JSON-like dictionary")
+    return Program.Schema().load(raw_program)
+
+
+def _parse_hash_function(raw_hash_function: Any) -> int:
+    if raw_hash_function is None:
+        return HashFunction.PEDERSEN.value
+    if isinstance(raw_hash_function, int):
+        return raw_hash_function
+    if isinstance(raw_hash_function, str):
+        return HashFunction[raw_hash_function.upper()].value
+    raise TypeError("Unsupported hash function specification")
+
+
+def build_single_program_bootloader_input(raw_input: Dict[str, Any]):
+    """Builds a ``SimpleBootloaderInput`` for running a single Cairo 1 program.
+
+    ``raw_input`` is expected to contain the compiled program under the ``"program"`` key
+    and the encoded program input under ``"program_input"``. Optional keys:
+    ``"program_hash_function"`` (string or integer compatible with ``HashFunction``),
+    ``"single_page"`` and ``"fact_topologies_path"``.
+    """
+
+    if raw_input is None:
+        raise TypeError("program_input must not be None")
+    if "program" not in raw_input:
+        raise KeyError("program_input must contain a 'program' entry")
+
+    program = _parse_program(raw_program=raw_input["program"])
+    program_input = raw_input.get("program_input")
+    hash_function = _parse_hash_function(raw_input.get("program_hash_function"))
+
+    task_cls = _resolve_task_class()
+    task = task_cls(
+        program=program,
+        program_input=program_input,
+        program_hash_function=hash_function,
+    )
+
+    input_cls = _resolve_input_class()
+    return input_cls(
+        tasks=[task],
+        fact_topologies_path=raw_input.get("fact_topologies_path"),
+        single_page=raw_input.get("single_page", True),
+    )


### PR DESCRIPTION
## Summary
- add a cairo0 entry point that bootloads a single Cairo 1 program by delegating to the simple bootloader
- provide a Python helper that converts raw program payloads into a SimpleBootloaderInput with one RunProgramTask
- update the design note to reflect the concrete implementation and helper module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e524b90cd883298ee8ef03e47f1fd0